### PR TITLE
Add GitHub Pages deployment for demo site

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,47 @@
+name: Deploy Demo
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 25
+      - uses: bytecodealliance/actions/wasm-tools/setup@v1
+        with:
+          version: '1.245.1'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      - name: Install cargo-wasm2map
+        run: cargo install cargo-wasm2map
+      - name: Download WASI adapter
+        run: |
+          curl -Lo wasi_adapter.wasm "https://github.com/bytecodealliance/wasmtime/releases/download/v42.0.1/wasi_snapshot_preview1.reactor.wasm"
+      - run: npm ci
+      - run: npm run demo:build
+        env:
+          WASI_ADAPTER: wasi_adapter.wasm
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: demo/dist
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wcjs
 
-Runtime, codegen, and CLI for using [WebAssembly components](https://component-model.bytecodealliance.org/) and [WASI P3](https://wasi.dev/roadmap#upcoming-wasi-03-releases) in the browser and Node.js. Call and expose asynchronous WebAssembly code with ergonomic, fully-typed TypeScript bindings.
+Runtime, codegen, and CLI for using [WebAssembly components](https://component-model.bytecodealliance.org/) and [WASI P3](https://wasi.dev/roadmap#upcoming-wasi-03-releases) in the browser and Node.js. Call and expose asynchronous WebAssembly code with ergonomic, fully-typed TypeScript bindings. **[Try the live demo.](https://jellevandenhooff.github.io/wcjs/)**
 
 > **Warning:** This project is extremely experimental. APIs will change, things will break, and it's not easy to use yet. All code was written by LLM, with plenty of review and feedback. That said, a large test suite passes (including the component model spec tests and ported wasmtime integration tests) and it does seem to work.
 

--- a/demo/build.sh
+++ b/demo/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-ADAPTER=../wasmtime/target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm
+ADAPTER=${WASI_ADAPTER:-../wasmtime/target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm}
 
 echo "==> Building Rust guest..."
 cargo build --target=wasm32-wasip1 --manifest-path demo/guest/Cargo.toml

--- a/demo/web/index.html
+++ b/demo/web/index.html
@@ -7,13 +7,20 @@
   <style>
     body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; color: #222; }
     h1 { margin-bottom: 0.25rem; }
-    p { color: #666; margin-bottom: 1.5rem; }
+    p { color: #666; margin-top: 0.5rem; margin-bottom: 0.5rem; }
+    p:last-of-type { margin-bottom: 1.5rem; }
+    a { color: #0366d6; }
+    code { background: #f0f0f0; padding: 0.15em 0.35em; border-radius: 3px; font-size: 0.9em; }
     pre { background: #1a1a2e; color: #0f0; border-radius: 8px; padding: 1rem; font-size: 0.85rem; min-height: 120px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; }
   </style>
 </head>
 <body>
   <h1>wcjs demo</h1>
-  <p>Rust WASI P3 async component running in the browser</p>
+  <p>Rust WASI P3 async component running in the browser. Requires Chrome (for <a href="https://github.com/nicolo-ribaudo/tc39-proposal-jspi">JSPI</a>).</p>
+  <p>Open DevTools and look around! The Rust guest source is visible in the debugger with source maps.
+    See <a href="https://github.com/jellevandenhooff/wcjs/blob/main/demo/web/main.ts"><code>demo/web/main.ts</code></a> for the host,
+    <a href="https://github.com/jellevandenhooff/wcjs/blob/main/demo/guest/src/lib.rs"><code>demo/guest/src/lib.rs</code></a> for the Rust guest,
+    and <a href="https://github.com/jellevandenhooff/wcjs/tree/main/src/runtime"><code>src/runtime/</code></a> for the async component model runtime.</p>
   <pre id="log"></pre>
   <script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
- New workflow (.github/workflows/demo.yml) deploys demo/dist/ to GitHub Pages on push to main, with manual trigger support
- Downloads WASI adapter from wasmtime releases instead of requiring sibling repo
- Make adapter path configurable via WASI_ADAPTER env var in demo/build.sh
- Add live demo link to top of README
- Update demo page with Chrome/JSPI note and source code pointers